### PR TITLE
Demo cleanup

### DIFF
--- a/src/components/DimensionsEditor/DimensionsEditor.vue
+++ b/src/components/DimensionsEditor/DimensionsEditor.vue
@@ -54,8 +54,6 @@
         <td />
       </tr>
     </table>
-
-    <pre>{{ policy }}</pre>
   </div>
 </template>
 
@@ -187,6 +185,10 @@ export default {
 </script>
 
 <style scoped>
+.section-heading {
+  margin-top: 40px;
+}
+
 .name-input {
   display: block;
   width: 100%;
@@ -197,8 +199,8 @@ export default {
 }
 
 table.prices-table {
+  margin-top: 15px;
   border-collapse: collapse;
-  margin: 0px auto;
 }
 th {
   font-weight: normal;

--- a/src/components/DimensionsEditor/RuleSection.vue
+++ b/src/components/DimensionsEditor/RuleSection.vue
@@ -5,6 +5,7 @@
       Hier geht es darum, welche Aktionen später mit den Medien erlaubt sein sollen.
       Suchen Sie aus der Liste links die Regeln, die Sie erlauben.
     </p>
+    <br>
     <table
       v-for="rule in rules"
       :key="rule.id"
@@ -62,6 +63,10 @@ export default {
 };
 </script>
 <style scoped>
+.section-heading {
+  margin-top: 40px;
+}
+
 h3 {
     font-weight: bold;
     font-size: inherit;

--- a/src/components/RuleEditor.vue
+++ b/src/components/RuleEditor.vue
@@ -74,13 +74,6 @@
       />
     </div>
 
-    <div class="policy-meaning">
-      <h2>Was bedeutet diese Lizenz?</h2>
-      <p v-html="licenceText" />
-      <h2>Provisorische Lizenz</h2>
-      <pre>{{ policy }}</pre>
-    </div>
-
   </div>
 </template>
 

--- a/src/libs/odrl/actions.js
+++ b/src/libs/odrl/actions.js
@@ -1,12 +1,10 @@
 export const actionList = [
-  'http://www.w3.org/ns/odrl/2/play',
-  'http://www.w3.org/ns/odrl/2/archive',
+  'http://www.w3.org/ns/odrl/2/public-screening',
+  'http://www.w3.org/ns/odrl/2/download',
+  'http://www.w3.org/ns/odrl/2/streaming',
+  'http://www.w3.org/ns/odrl/2/save',
   'http://www.w3.org/ns/odrl/2/derive',
-  'http://www.w3.org/ns/odrl/2/print',
-  'http://www.w3.org/ns/odrl/2/reproduce',
   'http://www.w3.org/ns/odrl/2/distribute',
-  'http://www.w3.org/ns/odrl/2/compensate',
-  'http://www.w3.org/ns/odrl/2/present',
 ];
 
 class Action {

--- a/src/libs/odrl/constraints.js
+++ b/src/libs/odrl/constraints.js
@@ -45,6 +45,12 @@ const states = [
   'http://schema.org/State/Germany/Thüringen',
 ];
 
+const resolutions = [
+  'http://www.example.org/resolution/tv/hd',
+  'http://www.example.org/resolution/tv/full-hd',
+  'http://www.example.org/resolition/tv/4k',
+];
+
 export const operandList = [
   'http://www.example.org/state',
   'http://www.example.org/group-identity',
@@ -59,6 +65,7 @@ export const operandList = [
   'http://www.example.org/distribution-method',
   'http://www.example.org/file-format',
   'http://www.example.org/pay-amount',
+  'http://www.example.org/tv-resolution',
 ];
 
 export const constraintOnlyOperandList = [
@@ -149,6 +156,10 @@ export const operandMapping = Object.freeze({
     operators: operatorList,
     units: [unitList[8], unitList[9]],
   },
+  'http://www.example.org/tv-resolution': {
+    operators: operatorList,
+    list: resolutions,
+  },
 });
 
 export const actionToRefinements = Object.freeze({
@@ -168,12 +179,24 @@ export const actionToRefinements = Object.freeze({
     operands: [operandList[7], operandList[11]],
   },
   'http://www.w3.org/ns/odrl/2/distribute': {
-    operands: [operandList[6], operandList[7], operandList[9], operandList[10], operandList[11]],
+    operands: [operandList[6], operandList[7], operandList[1], operandList[10], operandList[11]],
   },
   'http://www.w3.org/ns/odrl/2/compensate': {
     operands: [operandList[12]],
   },
   'http://www.w3.org/ns/odrl/2/present': {
     operands: [operandList[6], operandList[7], operandList[9]],
+  },
+  'http://www.w3.org/ns/odrl/2/public-screening': {
+    operands: [operandList[1], operandList[6], operandList[13]],
+  },
+  'http://www.w3.org/ns/odrl/2/download': {
+    operands: [operandList[1], operandList[6]],
+  },
+  'http://www.w3.org/ns/odrl/2/streaming': {
+    operands: [operandList[1], operandList[6], operandList[13]],
+  },
+  'http://www.w3.org/ns/odrl/2/save': {
+    operands: [operandList[5], operandList[11]],
   },
 });

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -148,6 +148,11 @@
   "http://www.w3.org/ns/odrl/2/compensate": "Kompensieren",
   "http://www.w3.org/ns/odrl/2/present": "Vorführen",
 
+  "http://www.w3.org/ns/odrl/2/public-screening": "Öffentliches Vorführen",
+  "http://www.w3.org/ns/odrl/2/download": "Download",
+  "http://www.w3.org/ns/odrl/2/streaming": "Streaming",
+  "http://www.w3.org/ns/odrl/2/save": "Speichern",
+
   "http://www.example.org/state": "Bundesland",
   "http://www.example.org/group-identity": "Gruppenzugehörigkeit",
   "http://www.example.org/age": "Alter",
@@ -161,6 +166,7 @@
   "http://www.example.org/distribution-method": "Verbreitungsmethode",
   "http://www.example.org/file-format": "Dateiformat",
   "http://www.example.org/pay-amount": "Geldbetrag",
+  "http://www.example.org/tv-resolution": "Auflösung",
 
   "http://www.example.org/resource/year": "Jahre",
   "http://www.example.org/resource/day": "Tage",
@@ -209,5 +215,9 @@
   "http://schema.org/State/Germany/Sachsen": "Sachsen",
   "http://schema.org/State/Germany/Sachsen-Anhalt": "Sachsen-Anhalt",
   "http://schema.org/State/Germany/Schleswig-Holstein": "Schleswig-Holstein",
-  "http://schema.org/State/Germany/Thüringen": "Thüringen"
+  "http://schema.org/State/Germany/Thüringen": "Thüringen",
+
+  "http://www.example.org/resolution/tv/hd": "720p (HD)",
+  "http://www.example.org/resolution/tv/full-hd": "1080p (FULL HD)",
+  "http://www.example.org/resolition/tv/4k": "4K"
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -149,6 +149,11 @@
   "http://www.w3.org/ns/odrl/2/compensate": "Compensating",
   "http://www.w3.org/ns/odrl/2/present": "Presenting",
 
+  "http://www.w3.org/ns/odrl/2/public-screening": "Pulic Screening",
+  "http://www.w3.org/ns/odrl/2/download": "Download",
+  "http://www.w3.org/ns/odrl/2/streaming": "Streaming",
+  "http://www.w3.org/ns/odrl/2/save": "Saving",
+
   "http://www.example.org/state": "state",
   "http://www.example.org/group-identity": "group identity",
   "http://www.example.org/age": "age",
@@ -162,6 +167,7 @@
   "http://www.example.org/distribution-method": "distribution method",
   "http://www.example.org/file-format": "file format",
   "http://www.example.org/pay-amount": "pay amount",
+  "http://www.example.org/tv-resolution": "resolution",
 
   "http://www.example.org/resource/year": "years",
   "http://www.example.org/resource/day": "days",
@@ -210,5 +216,9 @@
   "http://schema.org/State/Germany/Sachsen": "Saxony",
   "http://schema.org/State/Germany/Sachsen-Anhalt": "Saxony-Anhalt",
   "http://schema.org/State/Germany/Schleswig-Holstein": "Schleswig-Holstein",
-  "http://schema.org/State/Germany/Thüringen": "Thuringia"
+  "http://schema.org/State/Germany/Thüringen": "Thuringia",
+
+  "http://www.example.org/resolution/tv/hd": "HD",
+  "http://www.example.org/resolution/tv/full-hd": "FULL HD",
+  "http://www.example.org/resolition/tv/4k": "4K"
 }

--- a/src/views/OER.vue
+++ b/src/views/OER.vue
@@ -16,10 +16,6 @@
       <h2>Was bedeutet diese Lizenz?</h2>
       <p v-html="licenceText" />
     </div>
-    <div>
-      <h2>Provisorische Lizenz:</h2>
-      <pre>{{ odrl }}</pre>
-    </div>
   </div>
 </template>
 


### PR DESCRIPTION
- die provisorische Lizenz wird nicht mehr angezeigt
- die auswählbaren Aktionen machen Sinn und sind hoffentlich praxisnah
- ein paar Ränder zu den Überschriften im Schul-Cloud Editor hinzugefügt (und Tabelle links)